### PR TITLE
Replace shadow fields with getters and setters in MixinLivingEntity.

### DIFF
--- a/src/main/java/com/qouteall/immersive_portals/mixin/common/MixinLivingEntity.java
+++ b/src/main/java/com/qouteall/immersive_portals/mixin/common/MixinLivingEntity.java
@@ -12,24 +12,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(LivingEntity.class)
 public class MixinLivingEntity {
     
-    @Shadow
-    private LivingEntity revengeTarget;
-    
-    @Shadow
-    private LivingEntity lastAttackedEntity;
-    
     //maybe avoid memory leak???
     @Inject(method = "Lnet/minecraft/entity/LivingEntity;tick()V", at = @At("RETURN"))
     private void onTickEnded(CallbackInfo ci) {
-        Entity this_ = (Entity) (Object) this;
-        if (revengeTarget != null) {
-            if (revengeTarget.world != this_.world) {
-                revengeTarget = null;
+        LivingEntity this_ = (LivingEntity) (Object) this;
+        if (this_.getRevengeTarget() != null) {
+            if (this_.getRevengeTarget().world != this_.world) {
+            	this_.setRevengeTarget(null);
             }
         }
-        if (lastAttackedEntity != null) {
-            if (lastAttackedEntity.world != this_.world) {
-                lastAttackedEntity = null;
+        if (this_.getLastAttackedEntity() != null) {
+            if (this_.getLastAttackedEntity().world != this_.world) {
+            	this_.setLastAttackedEntity(null);
             }
         }
     }


### PR DESCRIPTION
In an attempt to reduce the amount of mixins, this pull request removes the shadow fields from MixingLivingEntity and instead uses the public getters and setters available in LivingEntity.